### PR TITLE
SLING-11078 - Describe and Validate asRepoInitString Line Separator Requirement

### DIFF
--- a/src/main/java/org/apache/sling/repoinit/parser/operations/DeleteGroup.java
+++ b/src/main/java/org/apache/sling/repoinit/parser/operations/DeleteGroup.java
@@ -47,7 +47,7 @@ public class DeleteGroup extends Operation {
     @NotNull
     @Override
     public String asRepoInitString() {
-        return String.format("delete group %s", QuotableStringUtil.forRepoInitString(groupname));
+        return String.format("delete group %s%n", QuotableStringUtil.forRepoInitString(groupname));
     }
 
     public String getGroupname() {

--- a/src/main/java/org/apache/sling/repoinit/parser/operations/Operation.java
+++ b/src/main/java/org/apache/sling/repoinit/parser/operations/Operation.java
@@ -31,6 +31,14 @@ public abstract class Operation {
     
     protected abstract String getParametersDescription();
 
+    /**
+     * Converts this operation instance to a RepoInit string representation
+     * including the current operation parameters. The representation must be
+     * parsable back into an equivalent operation and must end with a OS-compatible
+     * line separator.
+     * 
+     * @return the repoinit string for the operation
+     */
     @NotNull
     public abstract String asRepoInitString();
 

--- a/src/test/java/org/apache/sling/repoinit/parser/operations/AsRepoInitTest.java
+++ b/src/test/java/org/apache/sling/repoinit/parser/operations/AsRepoInitTest.java
@@ -62,7 +62,7 @@ public class AsRepoInitTest {
 
     @Test
     public void checkResultAsRepoInit() throws Exception {
-        try(ParserTestCase tc = testCaseSupplier.get()){
+        try (ParserTestCase tc = testCaseSupplier.get()) {
             ParserTestCase.validate(rebuildInputScript(tc.input), tc.expected, tc);
         }
     }
@@ -72,9 +72,8 @@ public class AsRepoInitTest {
         try (ParserTestCase tc = testCaseSupplier.get()) {
             for (Operation o : new RepoInitParserService().parse(tc.input)) {
                 String repoinitStatement = o.asRepoInitString();
-                assertTrue(
-                        "Operation.asRepoInitString() should always end with an-OS compatible line separator. Not found for "
-                                + o.toString(),
+                assertTrue("Operation.asRepoInitString() should always end with an-OS " +
+                        "compatible line separator. Not found for " + o.toString(),
                         repoinitStatement.endsWith(System.lineSeparator()));
             }
         }

--- a/src/test/java/org/apache/sling/repoinit/parser/operations/AsRepoInitTest.java
+++ b/src/test/java/org/apache/sling/repoinit/parser/operations/AsRepoInitTest.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 import java.util.Collection;
+import java.util.function.Supplier;
 
 /** Similar to {@link ParserTest} but uses {@link Operation#asRepoInitString()})
  *  to rebuild the input script after parsing it, to verify that that operation
@@ -39,33 +40,43 @@ import java.util.Collection;
 @RunWith(Parameterized.class)
 public class AsRepoInitTest {
 
-    private final ParserTestCase tc;
+    private final Supplier<ParserTestCase> testCaseSupplier;
 
     @Parameters(name="{0}")
     public static Collection<Object[]> data() throws IOException {
-        return ParserTestCase.buildTestData();
+        return ParserTestCase.buildTestDataSuppliers();
     }
 
-    public AsRepoInitTest(ParserTestCase tc) {
-        this.tc = tc;
+    public AsRepoInitTest(String testName, Supplier<ParserTestCase> testCaseSupplier) {
+        this.testCaseSupplier = testCaseSupplier;
     }
 
     /** Rebuild the input script using {@link Operation#asRepoInitString()}) */
     private static Reader rebuildInputScript(Reader input) throws Exception {
         StringBuilder sb = new StringBuilder();
         for (Operation o : new RepoInitParserService().parse(input)) {
-            String repoinitStatement = o.asRepoInitString();
-            assertTrue(
-                    "Operation.asRepoInitString() should always end with an-OS agnostic line separator. Not found for "
-                            + o.toString(),
-                    repoinitStatement.endsWith(System.lineSeparator()));
-            sb.append(repoinitStatement);
+            sb.append(o.asRepoInitString());
         }
         return new StringReader(sb.toString());
     }
 
     @Test
     public void checkResultAsRepoInit() throws Exception {
-        ParserTestCase.validate(rebuildInputScript(tc.input), tc.expected, tc);
+        try(ParserTestCase tc = testCaseSupplier.get()){
+            ParserTestCase.validate(rebuildInputScript(tc.input), tc.expected, tc);
+        }
+    }
+
+    @Test
+    public void checkRepoInitStatementNewline() throws Exception {
+        try (ParserTestCase tc = testCaseSupplier.get()) {
+            for (Operation o : new RepoInitParserService().parse(tc.input)) {
+                String repoinitStatement = o.asRepoInitString();
+                assertTrue(
+                        "Operation.asRepoInitString() should always end with an-OS compatible line separator. Not found for "
+                                + o.toString(),
+                        repoinitStatement.endsWith(System.lineSeparator()));
+            }
+        }
     }
 }

--- a/src/test/java/org/apache/sling/repoinit/parser/operations/AsRepoInitTest.java
+++ b/src/test/java/org/apache/sling/repoinit/parser/operations/AsRepoInitTest.java
@@ -25,6 +25,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
+import static org.junit.Assert.assertTrue;
+
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
@@ -52,7 +54,12 @@ public class AsRepoInitTest {
     private static Reader rebuildInputScript(Reader input) throws Exception {
         StringBuilder sb = new StringBuilder();
         for (Operation o : new RepoInitParserService().parse(input)) {
-            sb.append(o.asRepoInitString());
+            String repoinitStatement = o.asRepoInitString();
+            assertTrue(
+                    "Operation.asRepoInitString() should always end with an-OS agnostic line separator. Not found for "
+                            + o.toString(),
+                    repoinitStatement.endsWith(System.lineSeparator()));
+            sb.append(repoinitStatement);
         }
         return new StringReader(sb.toString());
     }

--- a/src/test/java/org/apache/sling/repoinit/parser/test/ParserTestCase.java
+++ b/src/test/java/org/apache/sling/repoinit/parser/test/ParserTestCase.java
@@ -136,7 +136,7 @@ public class ParserTestCase implements Closeable {
                 }
             };
             try (ParserTestCase tc = supplier.get()) {
-                if(tc != null){
+                if (tc != null) {
                     result.add(new Object[] { ParserTestCase.getFileName(i), supplier });
                 }
             }


### PR DESCRIPTION
## Changes

 - Resolves the regression introduced with SLING-10952 where DeleteGroup.asRepoInitString() no longer has a newline
 - Adds JavaDoc to describe the intended format for the Operation.asRepoInitString() representation
 - Add a new method to the ParserTestCase to get a supplier of test cases as the ParserTestCase objects are not reusable for multiple tests within a parameterized test
 - Adds a test to check the presence of a line separator in the representation

 
