### PR TITLE
SLING-10740 Bump the org.apache.sling.repoinit.language version number

### DIFF
--- a/bnd.bnd
+++ b/bnd.bnd
@@ -1,4 +1,4 @@
 -includeresource:\
   @jackrabbit-jcr-commons-*.jar!/org/apache/jackrabbit/util/ISO8601.*
 
-Provide-Capability: org.apache.sling.repoinit.language;version:Version="8.4"
+Provide-Capability: org.apache.sling.repoinit.language;version:Version="8.5"


### PR DESCRIPTION
Changes to the parser should declare a new version of the language to avoid out-of-sync version of the jcr.repoinit bundle