### PR TITLE
SLING-11402 Update to Sling Bundle Parent 48

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.sling</groupId>
     <artifactId>sling-bundle-parent</artifactId>
-    <version>41</version>
+    <version>48</version>
     <relativePath />
   </parent>
 
@@ -109,7 +109,6 @@
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
-            <version>18.0.0</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/org/apache/sling/repoinit/parser/operations/CreateGroup.java
+++ b/src/main/java/org/apache/sling/repoinit/parser/operations/CreateGroup.java
@@ -18,7 +18,6 @@
 package org.apache.sling.repoinit.parser.operations;
 
 import org.apache.sling.repoinit.parser.impl.QuotableStringUtil;
-import org.apache.sling.repoinit.parser.impl.WithPathOptions;
 import org.jetbrains.annotations.NotNull;
 import org.osgi.annotation.versioning.ProviderType;
 

--- a/src/main/java/org/apache/sling/repoinit/parser/operations/CreateServiceUser.java
+++ b/src/main/java/org/apache/sling/repoinit/parser/operations/CreateServiceUser.java
@@ -17,7 +17,6 @@
 
 package org.apache.sling.repoinit.parser.operations;
 
-import org.apache.sling.repoinit.parser.impl.WithPathOptions;
 import org.jetbrains.annotations.NotNull;
 import org.osgi.annotation.versioning.ProviderType;
 

--- a/src/main/java/org/apache/sling/repoinit/parser/operations/CreateUser.java
+++ b/src/main/java/org/apache/sling/repoinit/parser/operations/CreateUser.java
@@ -17,7 +17,6 @@
 
 package org.apache.sling.repoinit.parser.operations;
 
-import org.apache.sling.repoinit.parser.impl.WithPathOptions;
 import org.jetbrains.annotations.NotNull;
 import org.osgi.annotation.versioning.ProviderType;
 

--- a/src/main/java/org/apache/sling/repoinit/parser/operations/OperationWithPathOptions.java
+++ b/src/main/java/org/apache/sling/repoinit/parser/operations/OperationWithPathOptions.java
@@ -17,7 +17,6 @@
 
 package org.apache.sling.repoinit.parser.operations;
 
-import org.apache.sling.repoinit.parser.impl.WithPathOptions;
 import org.jetbrains.annotations.NotNull;
 import org.osgi.annotation.versioning.ProviderType;
 

--- a/src/main/java/org/apache/sling/repoinit/parser/operations/PropertyLine.java
+++ b/src/main/java/org/apache/sling/repoinit/parser/operations/PropertyLine.java
@@ -53,7 +53,7 @@ public class PropertyLine {
      *  @param isDefault true if this line is a "default" as opposed to a "set" instruction
      *  @throws ParseException if the line cannot be parsed.
      */
-    public PropertyLine(String name, String typeString, List<String> values, boolean isDefault) throws ParseException {
+    public PropertyLine(String name, String typeString, List<String> values, boolean isDefault) throws Exception { // NOSONAR
         this.name = name;
         boolean forceList = typeString != null && typeString.endsWith(MULTI_TOKEN);
         if(forceList) {

--- a/src/main/java/org/apache/sling/repoinit/parser/operations/ServiceUserOperation.java
+++ b/src/main/java/org/apache/sling/repoinit/parser/operations/ServiceUserOperation.java
@@ -17,7 +17,6 @@
 
 package org.apache.sling.repoinit.parser.operations;
 
-import org.apache.sling.repoinit.parser.impl.WithPathOptions;
 import org.osgi.annotation.versioning.ProviderType;
 
 @ProviderType

--- a/src/main/java/org/apache/sling/repoinit/parser/operations/WithPathOptions.java
+++ b/src/main/java/org/apache/sling/repoinit/parser/operations/WithPathOptions.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.sling.repoinit.parser.impl;
+package org.apache.sling.repoinit.parser.operations;
 
 public class WithPathOptions {
     public final String path;

--- a/src/main/java/org/apache/sling/repoinit/parser/operations/package-info.java
+++ b/src/main/java/org/apache/sling/repoinit/parser/operations/package-info.java
@@ -15,8 +15,6 @@
  * limitations under the License.
  ******************************************************************************/
 
- // DO NOT use version 5.x here, once a major change is
- // needed skip directly to 6.x (SLING-10139)
-@org.osgi.annotation.versioning.Version("4.10.0")
+@org.osgi.annotation.versioning.Version("6.0.0")
 package org.apache.sling.repoinit.parser.operations;
 

--- a/src/main/javacc/RepoInitGrammar.jjt
+++ b/src/main/javacc/RepoInitGrammar.jjt
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.ArrayList;
 
 import org.apache.sling.repoinit.parser.operations.*;
-import org.apache.sling.repoinit.parser.impl.WithPathOptions;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/src/test/java/org/apache/sling/repoinit/parser/test/PropertyLineTest.java
+++ b/src/test/java/org/apache/sling/repoinit/parser/test/PropertyLineTest.java
@@ -22,31 +22,31 @@ import java.util.Arrays;
 import java.util.Date;
 
 import org.apache.jackrabbit.util.ISO8601;
-import org.apache.sling.repoinit.parser.operations.PropertyLine;
 import org.apache.sling.repoinit.parser.impl.ParseException;
+import org.apache.sling.repoinit.parser.operations.PropertyLine;
 import org.junit.Test;
 
 public class PropertyLineTest {
 
     @Test
-    public void testDefaultPropertyType() throws ParseException {
+    public void testDefaultPropertyType() throws Exception {
         final PropertyLine p = new PropertyLine("someName", null, null, false);
         assertEquals(PropertyLine.PropertyType.String, p.getPropertyType());
     }
 
     @Test
-    public void testValidPropertyType() throws ParseException {
+    public void testValidPropertyType() throws Exception {
         final PropertyLine p = new PropertyLine("someName", "Boolean", null, false);
         assertEquals(PropertyLine.PropertyType.Boolean, p.getPropertyType());
     }
 
     @Test(expected = ParseException.class)
-    public void testInvalidPropertyType() throws ParseException {
+    public void testInvalidPropertyType() throws Exception {
         new PropertyLine("someName", "invalidTypeName", null, false);
     }
 
     @Test
-    public void testValidDateFormat() throws ParseException {
+    public void testValidDateFormat() throws Exception {
         final Date now = new Date();
         final String [] value = { ISO8601.format(now) };
         final PropertyLine p = new PropertyLine("someName", "Date", Arrays.asList(value), false);
@@ -54,13 +54,13 @@ public class PropertyLineTest {
     }
 
     @Test(expected=ParseException.class)
-    public void testInvalidDateFormat() throws ParseException {
+    public void testInvalidDateFormat() throws Exception {
         final String [] notAnIsoDate = { "really not a date" };
         new PropertyLine("someName", "Date", Arrays.asList(notAnIsoDate), false);
     }
 
     @Test
-    public void testInvalidDateFormatAsString() throws ParseException {
+    public void testInvalidDateFormatAsString() throws Exception {
         final String [] notAnIsoDate = { "2020-03-24" };
         final PropertyLine p = new PropertyLine("someName", "String", Arrays.asList(notAnIsoDate), false);
         assertEquals(notAnIsoDate[0], p.getPropertyValues().get(0));


### PR DESCRIPTION
Update to the latest parent pom

NOTE: The latest bnd revealed the following problem during the build due to (not exported) private classes being referenced from the exported public APIs:
`
[ERROR] Failed to execute goal biz.aQute.bnd:bnd-maven-plugin:6.3.0:bnd-process (bnd-process) on project org.apache.sling.repoinit.parser: Export org.apache.sling.repoinit.parser.operations,  has 1,  private references [org.apache.sling.repoinit.parser.impl] -> [Help 1]
`
To resolve those "private references" troubles, these changes seem to be required:

- Move the impl/WithPathOptions class to the exported operations package
- Change the PropertyLine constructor to throw Exception instead of the not exported org.apache.sling.repoinit.parser.impl.ParseException 
- Bump the exported operations package version to 6.0.0 to account for the major changes due to the above refactoring
 

