### PR TITLE
SLING-11571 repoinit: allow add or remove mixin types

### DIFF
--- a/bnd.bnd
+++ b/bnd.bnd
@@ -1,4 +1,4 @@
 -includeresource:\
   @jackrabbit-jcr-commons-*.jar!/org/apache/jackrabbit/util/ISO8601.*
 
-Provide-Capability: org.apache.sling.repoinit.language;version:Version="8.5"
+Provide-Capability: org.apache.sling.repoinit.language;version:Version="8.6"

--- a/src/main/java/org/apache/sling/repoinit/parser/operations/AddMixins.java
+++ b/src/main/java/org/apache/sling/repoinit/parser/operations/AddMixins.java
@@ -18,7 +18,6 @@
 package org.apache.sling.repoinit.parser.operations;
 
 
-import java.util.Formatter;
 import java.util.List;
 
 import org.jetbrains.annotations.NotNull;
@@ -26,6 +25,8 @@ import org.osgi.annotation.versioning.ProviderType;
 
 @ProviderType
 public class AddMixins extends BaseMixinsOperation {
+
+    private static final String TO = "to";
 
     public AddMixins(List<String> mixins, List<String> paths) {
         super(mixins, paths);
@@ -38,19 +39,13 @@ public class AddMixins extends BaseMixinsOperation {
 
     @Override
     protected String getParametersDescription() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append(listToString(getMixins()));
-        sb.append(" to ").append(pathsToString(getPaths()));
-        return sb.toString();
+        return getParametersDescription(TO);
     }
 
     @NotNull
     @Override
     public String asRepoInitString() {
-        try (Formatter formatter = new Formatter()) {
-            formatter.format("add mixin %s to %s%n", listToString(getMixins()), pathsToString(getPaths()));
-            return formatter.toString();
-        }
+        return asRepoInitString("add", TO);
     }
 
 }

--- a/src/main/java/org/apache/sling/repoinit/parser/operations/AddMixins.java
+++ b/src/main/java/org/apache/sling/repoinit/parser/operations/AddMixins.java
@@ -25,13 +25,10 @@ import org.jetbrains.annotations.NotNull;
 import org.osgi.annotation.versioning.ProviderType;
 
 @ProviderType
-public class AddMixins extends Operation {
-    private final List<String> paths;
-    private final List<String> mixins;
+public class AddMixins extends BaseMixinsOperation {
 
     public AddMixins(List<String> mixins, List<String> paths) {
-        this.mixins = mixins;
-        this.paths = paths;
+        super(mixins, paths);
     }
 
     @Override
@@ -42,30 +39,18 @@ public class AddMixins extends Operation {
     @Override
     protected String getParametersDescription() {
         final StringBuilder sb = new StringBuilder();
-        if (mixins != null) {
-            sb.append(String.join(",", mixins));
-        }
-        if (paths != null) {
-            sb.append(" to ").append(String.join(",", paths));
-        }
+        sb.append(listToString(getMixins()));
+        sb.append(" to ").append(pathsToString(getPaths()));
         return sb.toString();
     }
 
     @NotNull
     @Override
     public String asRepoInitString() {
-        // FIXME: see SLING-10238 for type and quoted values that cannot be generated
-        //        exactly as they were originally defined in repo-init
         try (Formatter formatter = new Formatter()) {
-            formatter.format("add mixin %s to %s%n", listToString(mixins), pathsToString(paths));
+            formatter.format("add mixin %s to %s%n", listToString(getMixins()), pathsToString(getPaths()));
             return formatter.toString();
         }
     }
-
-    public List<String> getPaths() {
-        return paths;
-    }
-
-    public List<String> getMixins () {return mixins;}
 
 }

--- a/src/main/java/org/apache/sling/repoinit/parser/operations/AddMixins.java
+++ b/src/main/java/org/apache/sling/repoinit/parser/operations/AddMixins.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.sling.repoinit.parser.operations;
+
+
+import java.util.Formatter;
+import java.util.List;
+
+import org.jetbrains.annotations.NotNull;
+import org.osgi.annotation.versioning.ProviderType;
+
+@ProviderType
+public class AddMixins extends Operation {
+    private final List<String> paths;
+    private final List<String> mixins;
+
+    public AddMixins(List<String> mixins, List<String> paths) {
+        this.mixins = mixins;
+        this.paths = paths;
+    }
+
+    @Override
+    public void accept(OperationVisitor v) {
+        v.visitAddMixins(this);
+    }
+
+    @Override
+    protected String getParametersDescription() {
+        final StringBuilder sb = new StringBuilder();
+        if (mixins != null) {
+            sb.append(String.join(",", mixins));
+        }
+        if (paths != null) {
+            sb.append(" to ").append(String.join(",", paths));
+        }
+        return sb.toString();
+    }
+
+    @NotNull
+    @Override
+    public String asRepoInitString() {
+        // FIXME: see SLING-10238 for type and quoted values that cannot be generated
+        //        exactly as they were originally defined in repo-init
+        try (Formatter formatter = new Formatter()) {
+            formatter.format("add mixin %s to %s%n", listToString(mixins), pathsToString(paths));
+            return formatter.toString();
+        }
+    }
+
+    public List<String> getPaths() {
+        return paths;
+    }
+
+    public List<String> getMixins () {return mixins;}
+
+}

--- a/src/main/java/org/apache/sling/repoinit/parser/operations/BaseMixinsOperation.java
+++ b/src/main/java/org/apache/sling/repoinit/parser/operations/BaseMixinsOperation.java
@@ -19,7 +19,10 @@ package org.apache.sling.repoinit.parser.operations;
 
 
 import java.util.Collections;
+import java.util.Formatter;
 import java.util.List;
+
+import org.jetbrains.annotations.NotNull;
 
 public abstract class BaseMixinsOperation extends Operation {
     private final List<String> paths;
@@ -30,10 +33,32 @@ public abstract class BaseMixinsOperation extends Operation {
         this.paths = paths != null ? paths : Collections.emptyList();
     }
 
+    protected String getParametersDescription(String operator) {
+        final StringBuilder sb = new StringBuilder();
+        sb.append(listToString(getMixins()));
+        sb.append(" ").append(operator).append(" ");
+        sb.append(pathsToString(getPaths()));
+        return sb.toString();
+    }
+
+    @NotNull
+    protected String asRepoInitString(String action, String operator) {
+        try (Formatter formatter = new Formatter()) {
+            formatter.format("%s mixin %s %s %s%n",
+                    action,
+                    listToString(getMixins()),
+                    operator,
+                    pathsToString(getPaths()));
+            return formatter.toString();
+        }
+    }
+
     public List<String> getPaths() {
         return paths;
     }
 
-    public List<String> getMixins () {return mixins;}
+    public List<String> getMixins () {
+        return mixins;
+    }
 
 }

--- a/src/main/java/org/apache/sling/repoinit/parser/operations/BaseMixinsOperation.java
+++ b/src/main/java/org/apache/sling/repoinit/parser/operations/BaseMixinsOperation.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.sling.repoinit.parser.operations;
+
+
+import java.util.Collections;
+import java.util.List;
+
+public abstract class BaseMixinsOperation extends Operation {
+    private final List<String> paths;
+    private final List<String> mixins;
+
+    protected BaseMixinsOperation(List<String> mixins, List<String> paths) {
+        this.mixins = mixins != null ? mixins : Collections.emptyList();
+        this.paths = paths != null ? paths : Collections.emptyList();
+    }
+
+    public List<String> getPaths() {
+        return paths;
+    }
+
+    public List<String> getMixins () {return mixins;}
+
+}

--- a/src/main/java/org/apache/sling/repoinit/parser/operations/OperationVisitor.java
+++ b/src/main/java/org/apache/sling/repoinit/parser/operations/OperationVisitor.java
@@ -45,4 +45,7 @@ public interface OperationVisitor {
     default void visitDeleteAclPaths(DeleteAclPaths s) { throw new UnsupportedOperationException(); }
     default void visitDeleteAclPrincipalBased(DeleteAclPrincipalBased s) { throw new UnsupportedOperationException(); }
 
+    default void visitAddMixins(AddMixins s) { throw new UnsupportedOperationException(); }
+    default void visitRemoveMixins(RemoveMixins s) { throw new UnsupportedOperationException(); }
+
 }

--- a/src/main/java/org/apache/sling/repoinit/parser/operations/RemoveMixins.java
+++ b/src/main/java/org/apache/sling/repoinit/parser/operations/RemoveMixins.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.sling.repoinit.parser.operations;
+
+
+import java.util.Formatter;
+import java.util.List;
+
+import org.jetbrains.annotations.NotNull;
+import org.osgi.annotation.versioning.ProviderType;
+
+@ProviderType
+public class RemoveMixins extends Operation {
+    private final List<String> paths;
+    private final List<String> mixins;
+
+    public RemoveMixins(List<String> mixins, List<String> paths) {
+        this.mixins = mixins;
+        this.paths = paths;
+    }
+
+    @Override
+    public void accept(OperationVisitor v) {
+        v.visitRemoveMixins(this);
+    }
+
+    @Override
+    protected String getParametersDescription() {
+        final StringBuilder sb = new StringBuilder();
+        if (mixins != null) {
+            sb.append(String.join(",", mixins));
+        }
+        if (paths != null) {
+            sb.append(" from ").append(String.join(",", paths));
+        }
+        return sb.toString();
+    }
+
+    @NotNull
+    @Override
+    public String asRepoInitString() {
+        // FIXME: see SLING-10238 for type and quoted values that cannot be generated
+        //        exactly as they were originally defined in repo-init
+        try (Formatter formatter = new Formatter()) {
+            formatter.format("remove mixin %s from %s%n", listToString(mixins), pathsToString(paths));
+            return formatter.toString();
+        }
+    }
+
+    public List<String> getPaths() {
+        return paths;
+    }
+
+    public List<String> getMixins () {return mixins;}
+
+
+}

--- a/src/main/java/org/apache/sling/repoinit/parser/operations/RemoveMixins.java
+++ b/src/main/java/org/apache/sling/repoinit/parser/operations/RemoveMixins.java
@@ -25,13 +25,10 @@ import org.jetbrains.annotations.NotNull;
 import org.osgi.annotation.versioning.ProviderType;
 
 @ProviderType
-public class RemoveMixins extends Operation {
-    private final List<String> paths;
-    private final List<String> mixins;
+public class RemoveMixins extends BaseMixinsOperation {
 
     public RemoveMixins(List<String> mixins, List<String> paths) {
-        this.mixins = mixins;
-        this.paths = paths;
+        super(mixins, paths);
     }
 
     @Override
@@ -42,31 +39,18 @@ public class RemoveMixins extends Operation {
     @Override
     protected String getParametersDescription() {
         final StringBuilder sb = new StringBuilder();
-        if (mixins != null) {
-            sb.append(String.join(",", mixins));
-        }
-        if (paths != null) {
-            sb.append(" from ").append(String.join(",", paths));
-        }
+        sb.append(listToString(getMixins()));
+        sb.append(" from ").append(pathsToString(getPaths()));
         return sb.toString();
     }
 
     @NotNull
     @Override
     public String asRepoInitString() {
-        // FIXME: see SLING-10238 for type and quoted values that cannot be generated
-        //        exactly as they were originally defined in repo-init
         try (Formatter formatter = new Formatter()) {
-            formatter.format("remove mixin %s from %s%n", listToString(mixins), pathsToString(paths));
+            formatter.format("remove mixin %s from %s%n", listToString(getMixins()), pathsToString(getPaths()));
             return formatter.toString();
         }
     }
-
-    public List<String> getPaths() {
-        return paths;
-    }
-
-    public List<String> getMixins () {return mixins;}
-
 
 }

--- a/src/main/java/org/apache/sling/repoinit/parser/operations/RemoveMixins.java
+++ b/src/main/java/org/apache/sling/repoinit/parser/operations/RemoveMixins.java
@@ -18,7 +18,6 @@
 package org.apache.sling.repoinit.parser.operations;
 
 
-import java.util.Formatter;
 import java.util.List;
 
 import org.jetbrains.annotations.NotNull;
@@ -26,6 +25,8 @@ import org.osgi.annotation.versioning.ProviderType;
 
 @ProviderType
 public class RemoveMixins extends BaseMixinsOperation {
+
+    private static final String FROM = "from";
 
     public RemoveMixins(List<String> mixins, List<String> paths) {
         super(mixins, paths);
@@ -38,19 +39,13 @@ public class RemoveMixins extends BaseMixinsOperation {
 
     @Override
     protected String getParametersDescription() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append(listToString(getMixins()));
-        sb.append(" from ").append(pathsToString(getPaths()));
-        return sb.toString();
+        return getParametersDescription(FROM);
     }
 
     @NotNull
     @Override
     public String asRepoInitString() {
-        try (Formatter formatter = new Formatter()) {
-            formatter.format("remove mixin %s from %s%n", listToString(getMixins()), pathsToString(getPaths()));
-            return formatter.toString();
-        }
+        return asRepoInitString("remove", FROM);
     }
 
 }

--- a/src/main/java/org/apache/sling/repoinit/parser/operations/package-info.java
+++ b/src/main/java/org/apache/sling/repoinit/parser/operations/package-info.java
@@ -15,6 +15,6 @@
  * limitations under the License.
  ******************************************************************************/
 
-@org.osgi.annotation.versioning.Version("6.0.0")
+@org.osgi.annotation.versioning.Version("6.1.0")
 package org.apache.sling.repoinit.parser.operations;
 

--- a/src/main/javacc/RepoInitGrammar.jjt
+++ b/src/main/javacc/RepoInitGrammar.jjt
@@ -152,6 +152,8 @@ List<Operation> parse() :
         | removeAcePrincipals(result)
         | removeAcePrincipalBased(result)
         | createPathStatement(result)
+        | addMixins(result)
+        | removeMixins(result)
         | registerNamespaceStatement(result)
         | registerNodetypesStatement(result)
         | registerPrivilegeStatement(result)
@@ -331,6 +333,38 @@ void createPathStatement(List<Operation> result) :
     (<EOL> | <EOF>)
     
     { if(cp != null) result.add(cp); }
+}
+
+void addMixins(List<Operation> result) :
+{
+    List<String> mixins = null;
+    List<String> paths = null;
+}
+{
+    <ADD> <MIXIN>
+    mixins = namespacedItemsList()
+    <TO>
+    paths = pathsList()
+
+    {
+        result.add(new AddMixins(mixins, paths));
+    }
+}
+
+void removeMixins(List<Operation> result) :
+{
+    List<String> mixins = null;
+    List<String> paths = null;
+}
+{
+    <REMOVE> <MIXIN>
+    mixins = namespacedItemsList()
+    <FROM>
+    paths = pathsList()
+
+    {
+        result.add(new RemoveMixins(mixins, paths));
+    }
 }
 
 void setAclPaths(List<Operation> result) :

--- a/src/test/java/org/apache/sling/repoinit/parser/test/OperationToStringVisitor.java
+++ b/src/test/java/org/apache/sling/repoinit/parser/test/OperationToStringVisitor.java
@@ -44,7 +44,9 @@ import org.apache.sling.repoinit.parser.operations.SetAclPaths;
 import org.apache.sling.repoinit.parser.operations.SetAclPrincipalBased;
 import org.apache.sling.repoinit.parser.operations.SetAclPrincipals;
 import org.apache.sling.repoinit.parser.operations.AddGroupMembers;
+import org.apache.sling.repoinit.parser.operations.AddMixins;
 import org.apache.sling.repoinit.parser.operations.RemoveGroupMembers;
+import org.apache.sling.repoinit.parser.operations.RemoveMixins;
 import org.apache.sling.repoinit.parser.operations.SetProperties;
 import org.apache.sling.repoinit.parser.operations.PropertyLine;
 
@@ -307,4 +309,15 @@ class OperationToStringVisitor implements OperationVisitor {
             out.println(p);
         }
     }
+
+    @Override
+    public void visitAddMixins(AddMixins am) {
+        out.println(am.toString());
+    }
+
+    @Override
+    public void visitRemoveMixins(RemoveMixins rm) {
+        out.println(rm.toString());
+    }
+
 }

--- a/src/test/resources/testcases/test-72-output.txt
+++ b/src/test/resources/testcases/test-72-output.txt
@@ -1,0 +1,6 @@
+AddMixins mix:one to /thePath1
+AddMixins mix:one,mix:two to /thePath1,/thePath2
+AddMixins mix:three,mix:four to /thePath3,/thePath4
+RemoveMixins mix:one from /thePath1
+RemoveMixins mix:one,mix:two from /thePath1,/thePath2
+RemoveMixins mix:three,mix:four from /thePath3,/thePath4

--- a/src/test/resources/testcases/test-72.txt
+++ b/src/test/resources/testcases/test-72.txt
@@ -1,0 +1,7 @@
+add mixin mix:one to /thePath1
+add mixin mix:one,mix:two to /thePath1,/thePath2
+add mixin mix:three, mix:four to /thePath3, /thePath4
+
+remove mixin mix:one from /thePath1
+remove mixin mix:one,mix:two from /thePath1,/thePath2
+remove mixin mix:three, mix:four from /thePath3, /thePath4


### PR DESCRIPTION
The use case here is for a node that is created by a base feature.  Other (optional) features could add a mixin to the existing node later if they are also included in the distribution.

The proposed syntax would be:

add mixin mix:one to /thePath1
add mixin mix:one,mix:two to /thePath1,/thePath2

remove mixin mix:one from /thePath1
remove mixin mix:one,mix:two from /thePath1,/thePath2

If the specified paths do not exist, a warning is logged and nothing is changed.  Otherwise, the mixin is added (or removed) from those paths.