### PR TITLE
SLING-12668 Keep information about forced multi properties

### DIFF
--- a/src/main/java/org/apache/sling/repoinit/parser/operations/PropertyLine.java
+++ b/src/main/java/org/apache/sling/repoinit/parser/operations/PropertyLine.java
@@ -34,6 +34,7 @@ public class PropertyLine {
     private final PropertyType propertyType;
     private final List<Object> values;
     private boolean isDefault = false;
+    private boolean isMultiple = false;
     private static final String MULTI_TOKEN = "[]";
 
     /** Valid types for these properties */
@@ -58,6 +59,7 @@ public class PropertyLine {
         boolean forceList = typeString != null && typeString.endsWith(MULTI_TOKEN);
         if(forceList) {
             typeString = typeString.substring(0, typeString.length() - MULTI_TOKEN.length());
+            isMultiple = true;
         }
         this.propertyType = typeString == null ? PropertyType.String : parseType(typeString);
         this.values = parseList(this.propertyType, values);
@@ -119,6 +121,11 @@ public class PropertyLine {
      */
     public boolean isDefault() { return isDefault; }
 
+    /**
+     * @return true if property type is explicitly defined as multiple.
+     */
+    public boolean isMultiple() { return isMultiple; }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder();
@@ -131,6 +138,9 @@ public class PropertyLine {
         sb.append(name);
         sb.append("{");
         sb.append(propertyType.toString());
+        if (isMultiple) {
+            sb.append(MULTI_TOKEN);
+        }
         sb.append("}=[");
 
         String sep = "";

--- a/src/main/java/org/apache/sling/repoinit/parser/operations/SetProperties.java
+++ b/src/main/java/org/apache/sling/repoinit/parser/operations/SetProperties.java
@@ -61,7 +61,8 @@ public class SetProperties extends Operation {
         try (Formatter formatter = new Formatter()) {
             formatter.format("set properties on %s%n", pathsToString(paths));
             for (PropertyLine line : lines) {
-                String type = (line.getPropertyType() == null) ? "" : "{" + line.getPropertyType().name() + "}";
+                String typeMultiple = line.isMultiple() ? "[]" : "";
+                String type = (line.getPropertyType() == null) ? "" : "{" + line.getPropertyType().name() + typeMultiple + "}";
                 String values = valuesToString(line.getPropertyValues(), line.getPropertyType());
                 if (line.isDefault()) {
                     formatter.format("default %s%s to %s%n", line.getPropertyName(), type, values);

--- a/src/main/java/org/apache/sling/repoinit/parser/operations/package-info.java
+++ b/src/main/java/org/apache/sling/repoinit/parser/operations/package-info.java
@@ -15,6 +15,6 @@
  * limitations under the License.
  ******************************************************************************/
 
-@org.osgi.annotation.versioning.Version("6.2.0")
+@org.osgi.annotation.versioning.Version("6.3.0")
 package org.apache.sling.repoinit.parser.operations;
 

--- a/src/main/javacc/RepoInitGrammar.jjt
+++ b/src/main/javacc/RepoInitGrammar.jjt
@@ -971,15 +971,16 @@ void propertyLine(List<PropertyLine> lines) :
     List<String> values;
     Token t = null;
     boolean isDefault = false;
+    boolean isMulti = false;
 }
 {
     (t = <SET> | t = <SETDEF> {isDefault = true;} )
     ( name = <STRING> | name = <NAMESPACED_ITEM>)
-    ( <LCURLY> ( type = <STRING> ) <RCURLY> | <LCURLY> ( type = <STRING> ) <MULTI> <RCURLY> )?
+    ( <LCURLY> ( type = <STRING> ) <RCURLY> | <LCURLY> ( type = <STRING> ) <MULTI> <RCURLY> {isMulti = true;} )?
     <TO> ( values = propertyValuesList() )
     <EOL>
     {
-        lines.add(new PropertyLine(name.image, type == null ? null : type.image, values, isDefault));
+        lines.add(new PropertyLine(name.image, type == null ? null : type.image + (isMulti ? "[]" : ""), values, isDefault));
     }
 }
 

--- a/src/test/java/org/apache/sling/repoinit/parser/test/PropertyLineTest.java
+++ b/src/test/java/org/apache/sling/repoinit/parser/test/PropertyLineTest.java
@@ -17,6 +17,7 @@
 package org.apache.sling.repoinit.parser.test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
 import java.util.Date;
@@ -65,4 +66,12 @@ public class PropertyLineTest {
         final PropertyLine p = new PropertyLine("someName", "String", Arrays.asList(notAnIsoDate), false);
         assertEquals(notAnIsoDate[0], p.getPropertyValues().get(0));
     }
+
+    @Test
+    public void testMultiPropertyType() throws Exception {
+        final PropertyLine p = new PropertyLine("someName", "String[]", null, false);
+        assertEquals(PropertyLine.PropertyType.String, p.getPropertyType());
+        assertTrue(p.isMultiple());
+    }
+
 }

--- a/src/test/resources/testcases/test-67-output.txt
+++ b/src/test/resources/testcases/test-67-output.txt
@@ -20,10 +20,10 @@ SetProperties on /endkeyword
   PropertyLine endS{String}=[{String}one]
   PropertyLine two{String}=[{String}endS]
 SetProperties on /forcedMultiValue
-  PropertyLine singleMultiValue{String}=[{String}single]
-  PropertyLine emptyMultiValue{String}=[]
-  PropertyLine singleLongMultiValue{Long}=[{Long}1243]
-  PropertyLine emptyLongMultiValue{Long}=[]
+  PropertyLine singleMultiValue{String[]}=[{String}single]
+  PropertyLine emptyMultiValue{String[]}=[]
+  PropertyLine singleLongMultiValue{Long[]}=[{Long}1243]
+  PropertyLine emptyLongMultiValue{Long[]}=[]
 SetProperties on /blankLinesInList
   PropertyLine one{String}=[{String}two]
   PropertyLine two{String}=[{String}four]


### PR DESCRIPTION
Previously, information about the forced multi property type like in
```
set singleMultiValue{String[]} to "single"
```
was ignored when parsing a repoinit file.
but in order to actually store a property as multiple or not, we need to keep this information and make it accessible in the parser API.

this is a prerequisite of https://github.com/apache/sling-org-apache-sling-jcr-repoinit/pull/61